### PR TITLE
Update injection_container.py

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -4,3 +4,4 @@ Authors
 
 * Rodrigo Martins de Oliveira - https://github.com/allrod5
 * Craig Minihan - https://github.com/craigminihan
+* Teodor Kulej - https://github.com/mt3o

--- a/injectable/autowiring/autowiring_utils.py
+++ b/injectable/autowiring/autowiring_utils.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 
 from typing import Union, List, Tuple, Sequence, Iterable
 
@@ -15,8 +15,8 @@ def is_sequence(tp):
     return tp in [
         list,
         tuple,
-        collections.Sequence,
-        collections.Iterable,
+        collections.abc.Sequence,
+        collections.abc.Iterable,
         List,
         Tuple,
         Sequence,

--- a/injectable/container/injection_container.py
+++ b/injectable/container/injection_container.py
@@ -139,7 +139,7 @@ class InjectionContainer:
     def _link_dependencies(cls, search_path: str):
         files = cls._collect_python_files(search_path)
         for file in files:
-            if not cls._contains_injectables(file):
+            if not cls._contains_injectables(file, encoding="utf-8"):
                 continue
             if file.path in cls.LOADED_FILEPATHS:
                 continue
@@ -149,11 +149,13 @@ class InjectionContainer:
             cls.LOADING_FILEPATH = None
 
     @classmethod
-    def load_dependencies_from(cls, absolute_search_path: str, default_namespace: str):
+    def load_dependencies_from(
+        cls, absolute_search_path: str, default_namespace: str, encoding: str = "utf-8"
+    ):
         files = cls._collect_python_files(absolute_search_path)
         cls.LOADING_DEFAULT_NAMESPACE = default_namespace
         for file in files:
-            if not cls._contains_injectables(file):
+            if not cls._contains_injectables(file, encoding):
                 continue
             if file.path in cls.LOADED_FILEPATHS:
                 continue
@@ -169,8 +171,8 @@ class InjectionContainer:
         return collector.collect(search_path)
 
     @classmethod
-    def _contains_injectables(cls, file_entry: os.DirEntry) -> bool:
-        with open(file_entry, encoding='utf-8') as file:
+    def _contains_injectables(cls, file_entry: os.DirEntry, encoding: str) -> bool:
+        with open(file_entry, encoding=encoding) as file:
             source = file.read()
         # TODO: Consider the use of ast.parse for this
         return any(

--- a/injectable/container/injection_container.py
+++ b/injectable/container/injection_container.py
@@ -170,7 +170,7 @@ class InjectionContainer:
 
     @classmethod
     def _contains_injectables(cls, file_entry: os.DirEntry) -> bool:
-        with open(file_entry) as file:
+        with open(file_entry, encoding='utf-8') as file:
             source = file.read()
         # TODO: Consider the use of ast.parse for this
         return any(

--- a/injectable/container/load_injection_container.py
+++ b/injectable/container/load_injection_container.py
@@ -9,6 +9,7 @@ def load_injection_container(
     search_path: str = None,
     *,
     default_namespace: str = None,
+    encoding: str = "utf-8",
 ):
     """
     Loads injectables under the search path to a shared injection container under the
@@ -21,6 +22,8 @@ def load_injection_container(
             injectables which does not explicitly request to be addressed in a
             specific namespace. Defaults to
             :const:`injectable.constants.DEFAULT_NAMESPACE`.
+    :param encoding: (optional) defines which encoding to use when reading project files
+            to discover and register injectables. Defaults to ``utf-8``.
 
     Usage::
 
@@ -42,5 +45,5 @@ def load_injection_container(
         caller_path = os.path.dirname(get_caller_filepath())
         search_path = os.path.abspath(os.path.join(caller_path, search_path))
     InjectionContainer.load_dependencies_from(
-        search_path, default_namespace or DEFAULT_NAMESPACE
+        search_path, default_namespace or DEFAULT_NAMESPACE, encoding
     )

--- a/tests/fixes/issue_80/issue_80_fix_test.py
+++ b/tests/fixes/issue_80/issue_80_fix_test.py
@@ -1,0 +1,28 @@
+"""
+Test the fix for the issue 80:
+Injectable fails reading files with UTF-8 characters in Windows.
+https://github.com/allrod5/injectable/issues/80
+
+Injectable 3.4.4 and prior releases attempted to read files with the default system
+encoding, which is 'cp-1252' for Windows, and throws an UnicodeDecodeError when reading
+files with UTF-8 characters.
+
+This issue was fixed in injectable 3.4.5.
+"""
+from injectable import injectable, autowired, Autowired, load_injection_container
+
+
+@injectable
+class Foo80:
+    pass
+
+
+@autowired
+def bar(foo: Autowired(Foo80)):
+    """UTF-8 chars: ⏩⏰⏣⎇⎗⎙⏻⏿⏨⏆什"""
+    assert foo is not None
+
+
+def test_issue_80_fix():
+    load_injection_container()
+    bar()


### PR DESCRIPTION
Hello! 
I would like to submit a little quick fix for the bug I encountered. My code contains UTF-8 characters, and injectable fails on reading those files. 

Before the fix - the code reads all python files using a plain `open(file_entry)` statement, with default file encoding. That is cp-1252 on windows machines. So code containing non-cp1252 characters breaks the program. In my case, the failing character was 0x8f.
Change enforces file encoding as UTF-8 solving the issue.

As of python3 - python uses utf-8 for internal strings anyway.

I guess it would be a good idea to parametrize this further (as top-level kwargs? by env variable?), or perhaps to read python file header looking for a specific comment indicating file encoding, however, switch to utf-8 should be fine for most cases (are people intentionally using non-universal encodings?).