### PR TITLE
Add option to pass `select_innermost_module` during resolution

### DIFF
--- a/injectable/container/injection_container.py
+++ b/injectable/container/injection_container.py
@@ -156,7 +156,11 @@ class InjectionContainer:
 
     @classmethod
     def load_dependencies_from(
-        cls, absolute_search_path: str, default_namespace: str, encoding: str = "utf-8"
+        cls,
+        absolute_search_path: str,
+        default_namespace: str,
+        encoding: str = "utf-8",
+        select_innermost_module: bool = False,
     ):
         files = cls._collect_python_files(absolute_search_path)
         cls.LOADING_DEFAULT_NAMESPACE = default_namespace
@@ -169,7 +173,11 @@ class InjectionContainer:
                 continue
             cls.LOADING_FILEPATH = file.path
             try:
-                run_module(module_finder.find_module_name(file.path))
+                run_module(
+                    module_finder.find_module_name(
+                        file.path, innermost=select_innermost_module
+                    )
+                )
             except AttributeError:
                 # This is needed for some corner cases involving pytest
                 # See more at https://github.com/pytest-dev/pytest/issues/9007

--- a/injectable/container/load_injection_container.py
+++ b/injectable/container/load_injection_container.py
@@ -10,6 +10,7 @@ def load_injection_container(
     *,
     default_namespace: str = DEFAULT_NAMESPACE,
     encoding: str = "utf-8",
+    select_innermost_module: bool = False,
 ):
     """
     Loads injectables under the search path to a shared injection container under the
@@ -24,6 +25,10 @@ def load_injection_container(
             :const:`injectable.constants.DEFAULT_NAMESPACE`.
     :param encoding: (optional) defines which encoding to use when reading project files
             to discover and register injectables. Defaults to ``utf-8``.
+    :param select_innermost_module: (optional) defines whether or not the most detailed
+            sys.path should be used to resolve the module name.
+            Enabling this option helps with prefix-paths which could resolve to incorrect modules.
+            Defaults to ``false``.
 
     Usage::
 
@@ -44,4 +49,6 @@ def load_injection_container(
     elif not os.path.isabs(search_path):
         caller_path = os.path.dirname(get_caller_filepath())
         search_path = os.path.abspath(os.path.join(caller_path, search_path))
-    InjectionContainer.load_dependencies_from(search_path, default_namespace, encoding)
+    InjectionContainer.load_dependencies_from(
+        search_path, default_namespace, encoding, select_innermost_module
+    )


### PR DESCRIPTION
See https://github.com/roo-oliv/injectable/discussions/113#discussion-7964961

Resolves issue when `sys.path` has a prefix-path for the module path. (e.g. `PROJECT_ROOT` and `PROJECT_ROOT/.venv/lib/python3.11/site-packages`)

The default behaviour is to match the shortes path possible (or the outermost module) but this causes a module_name as follows: `.venv.lib.python3.11.site-packages.module_name`  while it most likely should be `module_name` as this is directly a subdir from the `site-packages`.

The default behaviour is set to use the outermost to ensure no breaking change with current version.